### PR TITLE
Profile link should use decodedUsername

### DIFF
--- a/template.mjs
+++ b/template.mjs
@@ -69,7 +69,7 @@ export default ({
             </small>
             |
             <small>
-              <span><a href="https://news.ycombinator.com/user?id=${encodedUsername}">profile</a></span>
+              <span><a href="https://news.ycombinator.com/user?id=${decodedUsername}">profile</a></span>
             </small>
             |
             <small>


### PR DESCRIPTION
The profile link to HN doesn't work since it uses the encodedUsername - that should be the decodedUsername me thinks!